### PR TITLE
Fix: Align pet birthdate validation with backend rules

### DIFF
--- a/lib/features/pets/pet_form_screen.dart
+++ b/lib/features/pets/pet_form_screen.dart
@@ -139,12 +139,18 @@ class _PetFormScreenState extends State<PetFormScreen> {
   }
 
   Future<void> _pickBirthDate() async {
-    final initialDate = _selectedBirthDate ?? DateTime.now();
+    final now = DateTime.now();
+    final lastDate = DateTime(now.year, now.month, now.day);
+    final firstDate = AppValidators.minimumPetBirthDate(lastDate);
+    final initialDate = _birthDatePickerInitialDate(
+      firstDate: firstDate,
+      lastDate: lastDate,
+    );
     final selected = await showDatePicker(
       context: context,
       initialDate: initialDate,
-      firstDate: DateTime(1900),
-      lastDate: DateTime.now(),
+      firstDate: firstDate,
+      lastDate: lastDate,
     );
 
     if (selected == null || !mounted) {
@@ -155,6 +161,29 @@ class _PetFormScreenState extends State<PetFormScreen> {
       _selectedBirthDate = selected;
       _birthDateController.text = formatApiDate(selected);
     });
+  }
+
+  DateTime _birthDatePickerInitialDate({
+    required DateTime firstDate,
+    required DateTime lastDate,
+  }) {
+    final selectedBirthDate = _selectedBirthDate;
+    if (selectedBirthDate == null) {
+      return lastDate;
+    }
+
+    final selectedDate = DateTime(
+      selectedBirthDate.year,
+      selectedBirthDate.month,
+      selectedBirthDate.day,
+    );
+    if (selectedDate.isBefore(firstDate)) {
+      return firstDate;
+    }
+    if (selectedDate.isAfter(lastDate)) {
+      return lastDate;
+    }
+    return selectedDate;
   }
 
   Future<void> _save() async {
@@ -288,7 +317,7 @@ class _PetFormScreenState extends State<PetFormScreen> {
                             suffixIcon: Icon(Icons.calendar_today_outlined),
                           ),
                           onTap: _pickBirthDate,
-                          validator: AppValidators.required('Birth date'),
+                          validator: AppValidators.petBirthDate('Birth date'),
                         ),
                         const SizedBox(height: 12),
                         DropdownButtonFormField<PetType>(

--- a/lib/shared/forms/app_validators.dart
+++ b/lib/shared/forms/app_validators.dart
@@ -17,6 +17,8 @@
 typedef StringValidator = String? Function(String? value);
 
 class AppValidators {
+  static const int petMaximumAgeYears = 50;
+
   static StringValidator compose(List<StringValidator> validators) {
     return (value) {
       for (final validator in validators) {
@@ -145,5 +147,62 @@ class AppValidators {
       }
       return null;
     };
+  }
+
+  static StringValidator petBirthDate(String fieldName, {DateTime? today}) {
+    return (value) {
+      final text = value?.trim() ?? '';
+      if (text.isEmpty) {
+        return '$fieldName is required.';
+      }
+
+      final birthDate = _parseApiDate(text);
+      if (birthDate == null) {
+        return '$fieldName must be a valid date.';
+      }
+
+      final currentDate = _dateOnly(today ?? DateTime.now());
+      if (birthDate.isAfter(currentDate)) {
+        return '$fieldName cannot be in the future.';
+      }
+
+      if (birthDate.isBefore(minimumPetBirthDate(currentDate))) {
+        return '$fieldName cannot be older than $petMaximumAgeYears years.';
+      }
+
+      return null;
+    };
+  }
+
+  static DateTime minimumPetBirthDate(DateTime today) {
+    final currentDate = _dateOnly(today);
+    final targetYear = currentDate.year - petMaximumAgeYears;
+    final lastDayOfTargetMonth = DateTime(
+      targetYear,
+      currentDate.month + 1,
+      0,
+    ).day;
+    final targetDay = currentDate.day > lastDayOfTargetMonth
+        ? lastDayOfTargetMonth
+        : currentDate.day;
+    return DateTime(targetYear, currentDate.month, targetDay);
+  }
+
+  static DateTime? _parseApiDate(String text) {
+    try {
+      final parsed = DateTime.parse(text);
+      final dateOnly = _dateOnly(parsed);
+      final formatted =
+          '${dateOnly.year.toString().padLeft(4, '0')}-'
+          '${dateOnly.month.toString().padLeft(2, '0')}-'
+          '${dateOnly.day.toString().padLeft(2, '0')}';
+      return formatted == text ? dateOnly : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static DateTime _dateOnly(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
   }
 }

--- a/test/app_validators_test.dart
+++ b/test/app_validators_test.dart
@@ -33,4 +33,40 @@ void main() {
       expect(validator('12345abcde'), 'Telephone must contain digits only.');
     });
   });
+
+  group('AppValidators.petBirthDate', () {
+    final today = DateTime(2026, 5, 13);
+    late StringValidator validator;
+
+    setUp(() {
+      validator = AppValidators.petBirthDate('Birth date', today: today);
+    });
+
+    test('accepts a date within the last 50 years', () {
+      expect(validator('2020-01-01'), isNull);
+    });
+
+    test('accepts exactly 50 years ago', () {
+      expect(validator('1976-05-13'), isNull);
+    });
+
+    test('rejects a missing date', () {
+      expect(validator(''), 'Birth date is required.');
+    });
+
+    test('rejects an invalid date value', () {
+      expect(validator('2020-02-30'), 'Birth date must be a valid date.');
+    });
+
+    test('rejects a future date', () {
+      expect(validator('2026-05-14'), 'Birth date cannot be in the future.');
+    });
+
+    test('rejects a date older than 50 years', () {
+      expect(
+        validator('1976-05-12'),
+        'Birth date cannot be older than 50 years.',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Description  
- Align pet birth date validation with the backend `PetAgeValidator`
- Limit the pet birth date picker to dates from today minus 50 years through today
- Add focused validator tests for valid, future, invalid, and older-than-50-years dates

Closes #8
