### PR TITLE
Implement pagination for owner list with v2 API support

### DIFF
--- a/lib/features/owners/owner_list_screen.dart
+++ b/lib/features/owners/owner_list_screen.dart
@@ -33,12 +33,17 @@ class OwnerListScreen extends StatefulWidget {
 }
 
 class _OwnerListScreenState extends State<OwnerListScreen> {
+  static const int _ownersPageSize = 5;
+
   late final OwnerService _ownerService = widget.ownerService ?? OwnerService();
   final TextEditingController _searchController = TextEditingController();
 
   bool _isLoading = true;
   String? _errorMessage;
   String _activeQuery = '';
+  int _currentPage = 0;
+  int _totalPages = 0;
+  int _totalElements = 0;
   List<Owner> _owners = const [];
 
   @override
@@ -53,22 +58,42 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
     super.dispose();
   }
 
-  Future<void> _loadOwners({String? lastName}) async {
+  bool get _hasPages => _totalElements > 0 && _totalPages > 0;
+
+  bool get _canGoPrevious => _currentPage > 0;
+
+  bool get _canGoNext => _hasPages && _currentPage < _totalPages - 1;
+
+  String get _pageLabel {
+    final displayPage = _hasPages ? _currentPage + 1 : 0;
+    return 'Page $displayPage of $_totalPages';
+  }
+
+  Future<void> _loadOwners({String? lastName, int? page}) async {
+    final requestedQuery = lastName?.trim() ?? _activeQuery;
+    final requestedPage = page ?? _currentPage;
+
     setState(() {
       _isLoading = true;
       _errorMessage = null;
-      _activeQuery = lastName?.trim() ?? '';
+      _activeQuery = requestedQuery;
+      _currentPage = requestedPage;
     });
 
     try {
-      final owners = await _ownerService.listOwners(
-        lastName: _activeQuery.isEmpty ? null : _activeQuery,
+      final ownersPage = await _ownerService.listOwnersPage(
+        lastName: requestedQuery.isEmpty ? null : requestedQuery,
+        page: requestedPage,
+        size: _ownersPageSize,
       );
       if (!mounted) {
         return;
       }
       setState(() {
-        _owners = owners;
+        _owners = ownersPage.content;
+        _currentPage = ownersPage.page;
+        _totalPages = ownersPage.totalPages;
+        _totalElements = ownersPage.totalElements;
       });
     } catch (error) {
       if (!mounted) {
@@ -89,15 +114,29 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
   Future<void> _openOwnerForm() async {
     final changed = await context.push<bool>(AppRoutes.ownerNew);
     if (changed == true) {
-      await _loadOwners(lastName: _activeQuery);
+      await _loadOwners();
     }
   }
 
   Future<void> _openOwnerDetail(Owner owner) async {
     final changed = await context.push<bool>(AppRoutes.owner(owner.id!));
     if (changed == true) {
-      await _loadOwners(lastName: _activeQuery);
+      await _loadOwners();
     }
+  }
+
+  Future<void> _goToPreviousPage() async {
+    if (!_canGoPrevious) {
+      return;
+    }
+    await _loadOwners(page: _currentPage - 1);
+  }
+
+  Future<void> _goToNextPage() async {
+    if (!_canGoNext) {
+      return;
+    }
+    await _loadOwners(page: _currentPage + 1);
   }
 
   @override
@@ -116,8 +155,12 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
                 child: _SearchOwnersForm(
                   controller: _searchController,
                   compact: compact,
-                  onSearch: () =>
-                      _loadOwners(lastName: _searchController.text.trim()),
+                  onSearch: () {
+                    _loadOwners(
+                      lastName: _searchController.text.trim(),
+                      page: 0,
+                    );
+                  },
                 ),
               ),
               Expanded(child: _buildContent()),
@@ -142,7 +185,7 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
           Align(
             alignment: Alignment.center,
             child: FilledButton(
-              onPressed: () => _loadOwners(lastName: _activeQuery),
+              onPressed: () => _loadOwners(),
               child: const Text('Retry'),
             ),
           ),
@@ -158,7 +201,7 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
           ? 'Add an owner to get started.'
           : 'Try a different last name or add a new owner.';
       return RefreshIndicator(
-        onRefresh: () => _loadOwners(lastName: _activeQuery),
+        onRefresh: () => _loadOwners(),
         child: ListView(
           padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
           children: [
@@ -173,7 +216,7 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
     }
 
     return RefreshIndicator(
-      onRefresh: () => _loadOwners(lastName: _activeQuery),
+      onRefresh: () => _loadOwners(),
       child: ListView(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
         children: [
@@ -193,6 +236,23 @@ class _OwnerListScreenState extends State<OwnerListScreen> {
                 ),
               );
             },
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              OutlinedButton(
+                onPressed: _canGoPrevious ? _goToPreviousPage : null,
+                child: const Text('Previous'),
+              ),
+              const SizedBox(width: 16),
+              Text(_pageLabel),
+              const SizedBox(width: 16),
+              OutlinedButton(
+                onPressed: _canGoNext ? _goToNextPage : null,
+                child: const Text('Next'),
+              ),
+            ],
           ),
           const SizedBox(height: 16),
           Align(

--- a/lib/features/owners/owner_page.dart
+++ b/lib/features/owners/owner_page.dart
@@ -1,0 +1,29 @@
+import 'owner.dart';
+
+class OwnerPage {
+  const OwnerPage({
+    required this.content,
+    required this.page,
+    required this.size,
+    required this.totalElements,
+    required this.totalPages,
+  });
+
+  final List<Owner> content;
+  final int page;
+  final int size;
+  final int totalElements;
+  final int totalPages;
+
+  factory OwnerPage.fromJson(Map<String, dynamic> json) {
+    return OwnerPage(
+      content: (json['content'] as List<dynamic>)
+          .map((item) => Owner.fromJson(item as Map<String, dynamic>))
+          .toList(),
+      page: json['page'] as int,
+      size: json['size'] as int,
+      totalElements: json['totalElements'] as int,
+      totalPages: json['totalPages'] as int,
+    );
+  }
+}

--- a/lib/features/owners/owner_service.dart
+++ b/lib/features/owners/owner_service.dart
@@ -16,6 +16,7 @@
 
 import '../../shared/network/api_client.dart';
 import 'owner.dart';
+import 'owner_page.dart';
 
 class OwnerService {
   OwnerService({ApiClient? apiClient}) : _apiClient = apiClient ?? ApiClient();
@@ -39,6 +40,24 @@ class OwnerService {
       }
       rethrow;
     }
+  }
+
+  Future<OwnerPage> listOwnersPage({
+    String? lastName,
+    required int page,
+    required int size,
+  }) async {
+    final data =
+        await _apiClient.getJson(
+              'v2/owners',
+              queryParameters: {
+                'lastName': lastName,
+                'page': page.toString(),
+                'size': size.toString(),
+              },
+            )
+            as Map<String, dynamic>;
+    return OwnerPage.fromJson(data);
   }
 
   Future<Owner> getOwner(int ownerId) async {

--- a/test/list_services_test.dart
+++ b/test/list_services_test.dart
@@ -46,6 +46,112 @@ void main() {
       expect(owners, isEmpty);
     });
 
+    test('OwnerService.listOwnersPage maps a successful page', () async {
+      final service = OwnerService(
+        apiClient: buildApiClient(
+          handler: (_) async => http.Response('''
+            {
+              "content": [
+                {
+                  "id": 1,
+                  "firstName": "George",
+                  "lastName": "Franklin",
+                  "address": "110 W. Liberty St.",
+                  "city": "Madison",
+                  "telephone": "6085551023",
+                  "pets": []
+                }
+              ],
+              "page": 0,
+              "size": 5,
+              "totalElements": 10,
+              "totalPages": 2
+            }
+            ''', 200),
+        ),
+      );
+
+      final ownersPage = await service.listOwnersPage(page: 0, size: 5);
+
+      expect(ownersPage.content, hasLength(1));
+      expect(ownersPage.content.first.fullName, 'George Franklin');
+      expect(ownersPage.page, 0);
+      expect(ownersPage.size, 5);
+      expect(ownersPage.totalElements, 10);
+      expect(ownersPage.totalPages, 2);
+    });
+
+    test(
+      'OwnerService.listOwnersPage sends v2 path and query params',
+      () async {
+        final service = OwnerService(
+          apiClient: buildApiClient(
+            handler: (request) async {
+              expect(request.url.path, '/v2/owners');
+              expect(request.url.queryParameters['lastName'], 'Dav');
+              expect(request.url.queryParameters['page'], '1');
+              expect(request.url.queryParameters['size'], '5');
+
+              return http.Response('''
+              {
+                "content": [],
+                "page": 1,
+                "size": 5,
+                "totalElements": 0,
+                "totalPages": 0
+              }
+              ''', 200);
+            },
+          ),
+        );
+
+        await service.listOwnersPage(lastName: 'Dav', page: 1, size: 5);
+      },
+    );
+
+    test('OwnerService.listOwnersPage maps empty page content', () async {
+      final service = OwnerService(
+        apiClient: buildApiClient(
+          handler: (_) async => http.Response('''
+            {
+              "content": [],
+              "page": 0,
+              "size": 5,
+              "totalElements": 0,
+              "totalPages": 0
+            }
+            ''', 200),
+        ),
+      );
+
+      final ownersPage = await service.listOwnersPage(page: 0, size: 5);
+
+      expect(ownersPage.content, isEmpty);
+      expect(ownersPage.page, 0);
+      expect(ownersPage.size, 5);
+      expect(ownersPage.totalElements, 0);
+      expect(ownersPage.totalPages, 0);
+    });
+
+    test('OwnerService.listOwnersPage surfaces API errors', () async {
+      final service = OwnerService(
+        apiClient: buildApiClient(
+          handler: (_) async => http.Response('Server error', 500),
+        ),
+      );
+
+      expect(
+        service.listOwnersPage(page: 0, size: 5),
+        throwsA(
+          isA<ApiException>().having(
+            (error) => error.statusCode,
+            'statusCode',
+            500,
+          ),
+        ),
+      );
+    });
+
     test('VetService returns an empty list on 404', () async {
       final service = VetService(
         apiClient: buildApiClient(handler: (_) async => http.Response('', 404)),

--- a/test/owner_list_screen_test.dart
+++ b/test/owner_list_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spring_petclinic_flutter/features/owners/owner.dart';
 import 'package:spring_petclinic_flutter/features/owners/owner_list_screen.dart';
+import 'package:spring_petclinic_flutter/features/owners/owner_page.dart';
 import 'package:spring_petclinic_flutter/features/owners/owner_service.dart';
 
 class FakeOwnerService extends OwnerService {
@@ -27,11 +28,21 @@ class FakeOwnerService extends OwnerService {
   final Object? error;
 
   @override
-  Future<List<Owner>> listOwners({String? lastName}) async {
+  Future<OwnerPage> listOwnersPage({
+    String? lastName,
+    required int page,
+    required int size,
+  }) async {
     if (error != null) {
       throw error!;
     }
-    return List<Owner>.unmodifiable(owners);
+    return OwnerPage(
+      content: List<Owner>.unmodifiable(owners),
+      page: page,
+      size: size,
+      totalElements: owners.length,
+      totalPages: owners.isEmpty ? 0 : 1,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
  - Add `OwnerPage` mapping and `OwnerService.listOwnersPage()`
  - Load owners through the new `v2/owners` paginated API
  - Add fixed-size pagination controls to `OwnerListScreen`
  - Keep existing loading, empty, error, refresh, and navigation reload behavior

## Note
This PR follows the implementation in https://github.com/spring-petclinic/spring-petclinic-rest/pull/328

##Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c2f99267-619e-48d4-a451-761fe8a2e957" />
<img width="738" height="1600" alt="image" src="https://github.com/user-attachments/assets/1cc6e7d4-4ac3-4136-b2e4-2c27d6c43271" />

