### PR TITLE
Fix/issue 9 schema validation errors

### DIFF
--- a/lib/shared/network/api_client.dart
+++ b/lib/shared/network/api_client.dart
@@ -150,6 +150,19 @@ class ApiClient {
     try {
       final decoded = jsonDecode(responseBody);
       if (decoded is Map<String, dynamic>) {
+        // Surface the first useful validation message from
+        // schemaValidationErrors in ProblemDetail responses.
+        final schemaErrors = decoded['schemaValidationErrors'];
+        if (schemaErrors is List && schemaErrors.isNotEmpty) {
+          final first = schemaErrors.first;
+          if (first is Map<String, dynamic>) {
+            final fieldMsg = first['message'] ?? first['defaultMessage'];
+            if (fieldMsg is String && fieldMsg.isNotEmpty) {
+              return fieldMsg;
+            }
+          }
+        }
+
         for (final key in ['detail', 'message', 'title', 'error']) {
           final value = decoded[key];
           if (value is String && value.isNotEmpty) {

--- a/test/api_client_test.dart
+++ b/test/api_client_test.dart
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:spring_petclinic_flutter/shared/network/api_client.dart';
+
+void main() {
+  group('ApiClient error parsing', () {
+    ApiClient buildApiClient({
+      required Future<http.Response> Function(http.Request request) handler,
+    }) {
+      return ApiClient(
+        client: MockClient(handler),
+        baseUrl: 'http://localhost',
+      );
+    }
+
+    test('extracts first schemaValidationErrors message', () async {
+      final body = jsonEncode({
+        'type': 'about:blank',
+        'title': 'Bad Request',
+        'status': 400,
+        'detail': 'Validation failed',
+        'schemaValidationErrors': [
+          {'field': 'name', 'message': 'must not be blank'},
+          {'field': 'birthDate', 'message': 'must not be null'},
+        ],
+      });
+
+      final apiClient = buildApiClient(
+        handler: (_) async => http.Response(body, 400),
+      );
+
+      expect(
+        apiClient.getJson('pets'),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.message, 'message', 'must not be blank')
+              .having((e) => e.statusCode, 'statusCode', 400),
+        ),
+      );
+    });
+
+    test('uses defaultMessage when message is absent', () async {
+      final body = jsonEncode({
+        'type': 'about:blank',
+        'title': 'Bad Request',
+        'status': 400,
+        'detail': 'Validation failed',
+        'schemaValidationErrors': [
+          {
+            'field': 'firstName',
+            'defaultMessage': 'size must be between 1 and 30',
+          },
+        ],
+      });
+
+      final apiClient = buildApiClient(
+        handler: (_) async => http.Response(body, 400),
+      );
+
+      expect(
+        apiClient.getJson('owners'),
+        throwsA(
+          isA<ApiException>().having(
+            (e) => e.message,
+            'message',
+            'size must be between 1 and 30',
+          ),
+        ),
+      );
+    });
+
+    test('falls back to detail when schemaValidationErrors is empty', () async {
+      final body = jsonEncode({
+        'type': 'about:blank',
+        'title': 'Bad Request',
+        'status': 400,
+        'detail': 'Validation failed',
+        'schemaValidationErrors': [],
+      });
+
+      final apiClient = buildApiClient(
+        handler: (_) async => http.Response(body, 400),
+      );
+
+      expect(
+        apiClient.getJson('owners'),
+        throwsA(
+          isA<ApiException>().having(
+            (e) => e.message,
+            'message',
+            'Validation failed',
+          ),
+        ),
+      );
+    });
+
+    test(
+      'falls back to detail when schemaValidationErrors is absent',
+      () async {
+        final body = jsonEncode({
+          'type': 'about:blank',
+          'title': 'Bad Request',
+          'status': 400,
+          'detail': 'Request body is invalid',
+        });
+
+        final apiClient = buildApiClient(
+          handler: (_) async => http.Response(body, 400),
+        );
+
+        expect(
+          apiClient.getJson('owners'),
+          throwsA(
+            isA<ApiException>().having(
+              (e) => e.message,
+              'message',
+              'Request body is invalid',
+            ),
+          ),
+        );
+      },
+    );
+
+    test('handles non-ProblemDetail error bodies', () async {
+      final apiClient = buildApiClient(
+        handler: (_) async => http.Response('Something went wrong', 500),
+      );
+
+      expect(
+        apiClient.getJson('pets'),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.message, 'message', 'Something went wrong')
+              .having((e) => e.statusCode, 'statusCode', 500),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #9

Updated _extractMessage() to parse schemaValidationErrors from ProblemDetail responses and surface the first useful validation message
Falls back to existing detail/message/title/error logic when the field is absent or empty
Added 5 focused tests in api_client_test.dart; all existing tests pass